### PR TITLE
fix(acp): accept Windows absolute paths in the cortex realHome guard

### DIFF
--- a/pi-extensions/lib/acp/overlay.ts
+++ b/pi-extensions/lib/acp/overlay.ts
@@ -46,7 +46,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 import type { AcpMcpServer } from "./config.js";
 
@@ -416,7 +416,7 @@ function cortexLinkIfExists(realPath: string, overlayPath: string): void {
  * Returns the isolated HOME/SNOWFLAKE_HOME the spawn env must carry.
  */
 export function ensureCortexDualHomeOverlay(params: CortexOverlayParams): CortexOverlayResult {
-	if (!params.realHome || !params.realHome.startsWith("/")) {
+	if (!params.realHome || !isAbsolute(params.realHome)) {
 		throw new Error(
 			`entwurf: cortex dual-HOME overlay requires an absolute realHome captured by the parent (got ${JSON.stringify(params.realHome)})`,
 		);


### PR DESCRIPTION
## Problem

`ensureCortexDualHomeOverlay` validates the parent-captured `realHome` with `startsWith("/")`, which is POSIX-only. On Windows `homedir()` returns a drive-letter path, so the D10 guard rejects every legitimate `realHome`:

```
Error: entwurf: cortex dual-HOME overlay requires an absolute realHome captured by the parent (got "C:\Users\86572")
```

`backend-adapter.ts:405` feeds the guard `homedir()` directly, so this fires 100% of the time on Windows — no cortex session can start there at all.

## Fix

Use `path.isAbsolute` instead of the `/` prefix test.

The D10 recontract's intent is unchanged: the child must never re-derive HOME, and a relative path is still refused. The check now just asks the platform what "absolute" means. The existing `check-acp-cortex` case feeds `"relative/home"`, which `isAbsolute` rejects on every platform, so that gate keeps its meaning exactly as written — no gate change needed.

Two lines: the `node:path` import and the condition.

## Backend coverage

Per invariant 7 — this touches the **cortex** overlay only. The claude overlay (`ensureClaudeConfigOverlay`) has no equivalent guard, so it is unaffected. No common-layer file is touched, nothing branches on a backend name.

## Verification

Ran on Windows 11 (Node 26, pnpm 10):

- `biome check` — clean (no errors; the 5 warnings / 7 infos are pre-existing on `main`)
- `tsc --noEmit` across the three tsconfigs — clean
- `./run.sh check-acp-sdk-surface` — 7/7 passed
- Guard exercised directly in both directions: an absolute `homedir()` is accepted and materializes the scope dir; `"relative/home"` still throws the same message.

Not run here, and why: `check-acp-cortex` and `check-mux-fresh-call` do not currently execute on Windows for reasons unrelated to this change — the former spawns `node_modules/.bin/tsc` (the POSIX shim, no `.cmd`), the latter spawns a `.sh` fixture as an executable. `check-mux-fresh-call` fails the same way on a clean `main` checkout here, so it is a pre-existing platform gap in the harness, not a regression from this patch. `pnpm check` itself also can't complete on Windows because pnpm runs scripts through `cmd.exe`, which cannot invoke `./run.sh`; I ran the individual lanes through Git Bash instead. Someone on Linux/macOS running the full `pnpm run check:full` would be a useful second signal.

## Note for maintainers

Windows users additionally need Developer Mode enabled, or `ensureClaudeConfigOverlay`'s auth passthrough fails with `EPERM: operation not permitted, symlink` (8 entries, ending in `Authentication required`). That is arguably worth its own fallback — junctions for directories, hard links for files, neither of which needs elevation — but I left it out: hard-linking `.credentials.json` would silently pin the overlay to a stale inode if the backend refreshes tokens via write-temp-then-rename, which trades a loud failure for a quiet one. Happy to open a separate issue if a Windows lane is in scope for the rail.